### PR TITLE
Fix: immediate recompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ If you have an issue, please create one. But, before:
 - try to run it with `--debug` flag and see the output
 - try to make create repro example
 
+## Building
+
+Run `tsc --build tsconfig.build.json` to transpile this project.
+
 ## Versioning
 
 Currently versioning is not stable and it is still treated as pre-release. You might expect some options API changes. If you want to avoid unexpected problems it is recommended to fixate the installed version and update only in case of issues, you may consult [CHANGELOG](CHANGELOG.md) for updates.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -256,8 +256,8 @@ export const makeCompiler = (
 
       const starTime = new Date().getTime()
 
-	  const fileName = params.compile
-	  const code = params.code || fs.readFileSync(fileName, 'utf-8')
+      const fileName = params.compile
+      const code = params.code || fs.readFileSync(fileName, 'utf-8')
       const m: any = {
         _compile: writeCompiled,
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -234,8 +234,6 @@ export const makeCompiler = (
       }
     },
     compile: function (params: CompileParams) {
-      const fileName = params.compile
-	  const code = params.code || fs.readFileSync(fileName, 'utf-8')
       const compiledPath = params.compiledPath
       
       // Prevent occasional duplicate compilation requests
@@ -255,7 +253,11 @@ export const makeCompiler = (
       if (fs.existsSync(compiledPath)) {
         return
       }
+
       const starTime = new Date().getTime()
+
+	  const fileName = params.compile
+	  const code = params.code || fs.readFileSync(fileName, 'utf-8')
       const m: any = {
         _compile: writeCompiled,
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -235,7 +235,7 @@ export const makeCompiler = (
     },
     compile: function (params: CompileParams) {
       const fileName = params.compile
-      const code = fs.readFileSync(fileName, 'utf-8')
+	  const code = params.code || fs.readFileSync(fileName, 'utf-8')
       const compiledPath = params.compiledPath
       
       // Prevent occasional duplicate compilation requests

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,9 +220,10 @@ export const runDev = (
     child.stopping = true
     child.respawn = true
     if (child.connected === undefined || child.connected === true) {
-      log.debug('Disconnecting from child')
-      child.disconnect()
-      if (!willTerminate) {
+      if (willTerminate) {
+        log.debug('Disconnecting from child')
+		child.disconnect()
+      } else {
         killChild()
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,7 +222,7 @@ export const runDev = (
     if (child.connected === undefined || child.connected === true) {
       if (willTerminate) {
         log.debug('Disconnecting from child')
-		child.disconnect()
+        child.disconnect()
       } else {
         killChild()
       }


### PR DESCRIPTION
We noticed that restarting the process upon changes did not work reliably if the process was still in the middle of compilation when the change occurred.

In that situation it seems like disconnecting from the child before sending the `SIGTERM` causes the child process to freeze. On my machine (MacOS 10.15, node.js 14.16.0) the child kept spinning at 100% CPU load, but did not react to `SIGTERM` – neither the one sent by `ts-node-dev` nor any signal sent manually.

Not disconnecting from the child before killing it resolves the issue. It has the added advantage of showing why restarting may take longer than expected because you still receive the old child’s log output and see, eg., when the old compilation finally finishes.

While investigating the cause of the hang, I also noticed that `ts-node-dev` read the content of every changed file _twice_ (and much earlier than needed). This PR fixes also fixes that.