### PR TITLE
Bump `dateformat` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.1",
-    "dateformat": "~1.0.4-1.2.3",
+    "dateformat": "^4.5.1",
     "dynamic-dedupe": "^0.3.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
Fixes https://github.com/wclr/ts-node-dev/issues/271

This project is impacted by this CVE https://www.npmjs.com/advisories/1753/versions by the following dependency chain: `dateformat@~1.0.4-1.2.3 -> meow@^3.3.0 -> trim-newlines@^1.0.0`

The test suite for this project is not passing on my machine (both before or after this version bump). Using the latest `dateformat` version "manually" as it it's used in `ts-node-dev` does give the expected result though.