### PR TITLE
Fix debounce issue #188

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -115,6 +115,7 @@ type DevOptions = {
   clear: boolean
   cls: boolean
   'ignore-watch': string
+  debounce: string
   'all-deps': boolean
   'deps-level': string
   'compile-timeout': string

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,17 @@ export const runDev = (
     }
   }
 
+  let debounceTimeout: ReturnType<typeof setTimeout>
+  const defaultDebounce: string = (opts.debounce === '') ? '1000' : opts.debounce
+  const debounceTime: number = parseInt(defaultDebounce, 10) || 0
   function restart(file: string, isManualRestart?: boolean) {
+    clearTimeout(debounceTimeout)
+    debounceTimeout = setTimeout(() => {
+      restartAfterDebounce(file, isManualRestart)
+    }, debounceTime)
+  }
+
+  function restartAfterDebounce(file: string, isManualRestart?: boolean) {
     if (file === compiler.tsConfigPath) {
       notify('Reinitializing TS compilation', '')
       compiler.init()


### PR DESCRIPTION
Added a setTimeout to call restart later.

Use with default 1 second debounce:
`ts-node-dev --debounce`
Or use with custom delay in ms:
`ts-node-dev --debounce 500`
Or just do not include the `--debounce` flag and use it without debounce.

https://github.com/wclr/ts-node-dev/issues/188