### PR TITLE
Allow for optional args in child_process.fork

### DIFF
--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -35,10 +35,19 @@ if (cfg.fork) {
   // too. We also need to relay messages about required files to the parent.
   const newFork = function (
     modulePath: string,
-    args: string[],
-    options: ForkOptions
-  ) {    
-    const child = oldFork(__filename, [modulePath].concat(args), options)
+    args?: string[] | ForkOptions,
+    options?: ForkOptions
+  ) {
+
+    let forkArgs: string[];
+    if (args instanceof Array) {
+      forkArgs = [modulePath].concat(args);
+    } else {
+      forkArgs = [modulePath];
+      options = args;
+    }
+
+    const child = oldFork(__filename, forkArgs, options)
     ipc.relay(child)
     return child
   }


### PR DESCRIPTION
[Child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) has args and options as optional arguments. When we tamper with the method we must account for that. Otherwise we get incorrect behaviour when the wrapped program calls something like `child_process.fork(filename, {...options})`.

This patch basically checks if arguments were supplied and allows to act accordingly.