### PR TITLE
fix: "Channel closed" error in child on graceful shutdown after SIGTERM

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "ts-node-dev": "node ./lib/bin",
     "build": "tsc -p tsconfig.build.json",
+    "prepare": "npm run build",
     "release": "np",
     "test": "yarn build && ts-node -T node_modules/mocha/bin/mocha test/*.test.ts",
     "test-dev": "yarn ts-node-dev -T --respawn --deps --watch lib node_modules/mocha/bin/mocha test/*.test.ts --output",

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,8 @@ export const runDev = (
     child.stopping = true
     child.respawn = true
     if (child.connected === undefined || child.connected === true) {
+      log.debug('Disconnecting from child')
+      child.disconnect()
       if (!willTerminate) {
         killChild()
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,8 +220,6 @@ export const runDev = (
     child.stopping = true
     child.respawn = true
     if (child.connected === undefined || child.connected === true) {
-      log.debug('Disconnecting from child')
-      child.disconnect()
       if (!willTerminate) {
         killChild()
       }

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -67,18 +67,22 @@ process.on('uncaughtException', function (err: any) {
     console.error((err && err.stack) || err)
   }
   
-  ipc.send({
-    error: isTsError ? '' : (err && err.name) || 'Error',
-    // lastRequired: lastRequired,
-    message: err ? err.message : '',
-    code: err && err.code,    
-    willTerminate: hasCustomHandler,
-  })
+  if (process.connected) {
+    ipc.send({
+      error: isTsError ? '' : (err && err.name) || 'Error',
+      // lastRequired: lastRequired,
+      message: err ? err.message : '',
+      code: err && err.code,    
+      willTerminate: hasCustomHandler,
+    })
+  }
 })
 
 // Hook into require() and notify the parent process about required files
 makeHook(cfg, module, function (file) {
-  ipc.send({ required: file })
+  if (process.connected) {
+    ipc.send({ required: file })
+  }
 })
 
 // Check if a module is registered for this extension


### PR DESCRIPTION
fixes wclr/ts-node-dev#320

I could not identify a reason why `child.disconnect()` is needed at all:
* If `willTerminate === false`, the chill will be killed anyway (and https://github.com/wclr/ts-node-dev/pull/256 is also suggesting it is not needed there). 
* If `willTerminate === true`, the child might need to require new files, for which the IPC is needed, so there we cannot disconnect. When the client exists, the IPC is disconnected anyway.