### PR TITLE
Fix: Permanently fixes #69 by forcefully shutting down hanging child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Look up flags and options can be used [in ts-node's docs](https://github.com/Typ
 * `--rs` - Allow to restart with "rs" line entered in stdio, disabled by default.
 * `--notify` - to display desktop-notifications (Notifications are only displayed if `node-notifier` is installed).
 * `--cache-directory` - tmp dir which is used to keep the compiled sources (by default os tmp directory is used)
-* `--shutdown-timeout` - When restarting a graceful shutdown is attempted. After this timeout a shutdown is forced if it did not complete by itself. (ms, default: 30000)
+* `--shutdown-timeout` - A graceful shutdown is attempted. If it does not complete before this timeout it will be force shutdown. (ms, default: 30000)
 
 If you need to detect that you are running with `ts-node-dev`, check if `process.env.TS_NODE_DEV` is set.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Look up flags and options can be used [in ts-node's docs](https://github.com/Typ
 * `--rs` - Allow to restart with "rs" line entered in stdio, disabled by default.
 * `--notify` - to display desktop-notifications (Notifications are only displayed if `node-notifier` is installed).
 * `--cache-directory` - tmp dir which is used to keep the compiled sources (by default os tmp directory is used)
+* `--shutdown-timeout` - When restarting a graceful shutdown is attempted. After this timeout a shutdown is forced if it did not complete by itself. (ms, default: 30000)
 
 If you need to detect that you are running with `ts-node-dev`, check if `process.env.TS_NODE_DEV` is set.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ts-node-dev",
-  "version": "2.0.0",
+  "name": "@sunsama/ts-node-dev",
+  "version": "2.0.1",
   "description": "Compiles your TS app and restarts when files are modified.",
   "keywords": [
     "restart",
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/whitecolor/ts-node-dev.git"
+    "url": "http://github.com/sunsama/ts-node-dev.git"
   },
   "license": "MIT",
   "bin": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -93,6 +93,7 @@ const devFlags = {
     'dir',
     'deps-level',
     'compile-timeout',
+    'shutdown-timeout',
     'ignore-watch',
     'interval',
     'debounce',
@@ -124,6 +125,7 @@ type DevOptions = {
   'error-recompile': boolean
   quiet: boolean
   'tree-kill': boolean
+  'shutdown-timeout': string
 }
 
 export type Options = {
@@ -142,6 +144,7 @@ const opts = minimist(devArgs, {
   },
   default: {
     fork: true,
+    ['shutdown-timeout']: '30000',
   },
   unknown: function (arg) {
     unknown.push(arg)


### PR DESCRIPTION
I ran into the issues described in #69 and I found that none of the proposed solutions were working for me.

In order to reproduce the issue I made sure to trigger a change in my node_modules before my application had fully started up. This seemed to always result in the `SIGTERM` being swallowed by some other listener instead of properly shutting down the application. This results in `ts-node-dev` perpetually hanging.

The solution here is to simply send a `SIGINT` after a preset delay if the `SIGTERM` does not result in the application exiting on it's own.