### PR TITLE
Expose @types/node as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "node-notifier": "*",
     "typescript": "*"
   },


### PR DESCRIPTION
ts-node declares `@types/node` as a peer dependency, so we've gotta also expose it in order to satisfy the peer dependency requirement

Fixes #319