### PR TITLE
fix: compile message not relayed by wrapper (#299)

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from 'child_process'
+import type { CompileParams } from './compiler'
 
 export type IPCMessage = {
   cmd?: string
@@ -12,8 +13,15 @@ export type IPCMessage = {
 /**
  * Checks if the given message is an internal node-dev message.
  */
-function isNodeDevMessage(m: IPCMessage) {
+function isNodeDevMessage(m: any): m is IPCMessage {
   return m.cmd === 'NODE_DEV'
+}
+
+/**
+ * Check if the given message is an compile request message.
+ */
+function isCompileRequestMessage(m: any): m is CompileParams {
+  return typeof m.compile === 'string' && typeof m.compiledPath === 'string'
 }
 
 /**
@@ -29,7 +37,7 @@ export const on = function (
   type: string,
   cb: (m: IPCMessage) => void
 ) {
-  function handleMessage(m: IPCMessage) {
+  function handleMessage(m: any) {
     if (isNodeDevMessage(m) && type in m) cb(m)
   }
   proc.on('internalMessage', handleMessage)
@@ -40,8 +48,8 @@ export const relay = function (
   src: ChildProcess,
   dest: NodeJS.Process = process
 ) {
-  function relayMessage(m: IPCMessage) {
-    if (isNodeDevMessage(m)) dest.send!(m)
+  function relayMessage(m: any) {
+    if (isNodeDevMessage(m) || isCompileRequestMessage(m)) dest.send!(m)
   }
   src.on('internalMessage', relayMessage)
   src.on('message', relayMessage)


### PR DESCRIPTION
This PR addresses #299 where compile requests from child processes were not being properly relayed, causing the forked scripts to fail to execute.