### PR TITLE
fix: Remove limitation of 100 arguments

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,7 +6,7 @@ import minimist from 'minimist'
 const nodeArgs: string[] = []
 const unknown: string[] = []
 
-const devArgs = process.argv.slice(2, 100)
+const devArgs = process.argv.slice(2)
 
 const tsNodeFlags = {
   boolean: [


### PR DESCRIPTION
**Problem**
I was using `ts-node-dev` to run some scripts with more than 100 arguments in `process.argv`. This limitation is not documented anywhere and it was hard to pinpoint why I wasn't getting all the arguments I supplied. After some debugging I boiled it down to this script.

**Solution**
Remove the artificatial limit of 100 arguments